### PR TITLE
Update DDL to v3 (add FK to account_roles)

### DIFF
--- a/ddl/MySQL/deploy/3/001-auto-__VERSION.sql
+++ b/ddl/MySQL/deploy/3/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::MySQL
+-- Created on Sun Apr  2 00:26:41 2017
+-- 
+;
+SET foreign_key_checks=0;
+--
+-- Table: `dbix_class_deploymenthandler_versions`
+--
+CREATE TABLE `dbix_class_deploymenthandler_versions` (
+  `id` integer NOT NULL auto_increment,
+  `version` varchar(50) NOT NULL,
+  `ddl` text NULL,
+  `upgrade_sql` text NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `dbix_class_deploymenthandler_versions_version` (`version`)
+);
+SET foreign_key_checks=1;

--- a/ddl/MySQL/deploy/3/001-auto.sql
+++ b/ddl/MySQL/deploy/3/001-auto.sql
@@ -1,0 +1,141 @@
+-- 
+-- Created by SQL::Translator::Producer::MySQL
+-- Created on Sun Apr  2 00:26:40 2017
+-- 
+;
+SET foreign_key_checks=0;
+--
+-- Table: `accounts`
+--
+CREATE TABLE `accounts` (
+  `account_id` integer unsigned NOT NULL auto_increment,
+  `email` char(128) NOT NULL,
+  `password` text NULL,
+  PRIMARY KEY (`account_id`),
+  UNIQUE `email` (`email`)
+) ENGINE=InnoDB;
+--
+-- Table: `items`
+--
+CREATE TABLE `items` (
+  `item_id` integer unsigned NOT NULL auto_increment,
+  `item_name` char(32) NOT NULL,
+  `item_type` char(32) NOT NULL,
+  `item_data` mediumtext NOT NULL,
+  PRIMARY KEY (`item_id`)
+) ENGINE=InnoDB;
+--
+-- Table: `maps`
+--
+CREATE TABLE `maps` (
+  `tile_id` integer unsigned NOT NULL,
+  `tile_x` integer NOT NULL,
+  `tile_y` integer NOT NULL,
+  `tile_z` integer NOT NULL,
+  PRIMARY KEY (`tile_id`),
+  UNIQUE `tile_coords` (`tile_x`, `tile_y`, `tile_z`)
+);
+--
+-- Table: `roles`
+--
+CREATE TABLE `roles` (
+  `role_id` integer unsigned NOT NULL auto_increment,
+  `role` char(255) NOT NULL,
+  `description` char(255) NULL,
+  PRIMARY KEY (`role_id`)
+) ENGINE=InnoDB;
+--
+-- Table: `sessions`
+--
+CREATE TABLE `sessions` (
+  `id` char(72) NOT NULL,
+  `session_data` mediumtext NULL,
+  `expires` integer NULL,
+  PRIMARY KEY (`id`)
+);
+--
+-- Table: `skills`
+--
+CREATE TABLE `skills` (
+  `skill_id` integer unsigned NOT NULL auto_increment,
+  `skill_name` char(32) NOT NULL,
+  `skill_requirements` char(32) NOT NULL,
+  `skill_data` mediumtext NOT NULL,
+  `skill_prerequisites` mediumtext NOT NULL,
+  PRIMARY KEY (`skill_id`)
+) ENGINE=InnoDB;
+--
+-- Table: `tiles`
+--
+CREATE TABLE `tiles` (
+  `tile_id` integer unsigned NOT NULL auto_increment,
+  `tile_name` char(32) NOT NULL,
+  `colour_code` char(6) NOT NULL,
+  `move_type` char(10) NOT NULL,
+  PRIMARY KEY (`tile_id`)
+) ENGINE=InnoDB;
+--
+-- Table: `characters`
+--
+CREATE TABLE `characters` (
+  `character_id` integer unsigned NOT NULL auto_increment,
+  `character_name` char(32) NOT NULL,
+  `account_id` integer unsigned NOT NULL,
+  `character_health` integer unsigned NOT NULL,
+  `character_exp` integer unsigned NOT NULL,
+  `character_max_ap` integer unsigned NOT NULL,
+  `character_ap` integer unsigned NOT NULL,
+  INDEX `characters_idx_account_id` (`account_id`),
+  PRIMARY KEY (`character_id`),
+  UNIQUE `character_name` (`character_name`),
+  CONSTRAINT `characters_fk_account_id` FOREIGN KEY (`account_id`) REFERENCES `accounts` (`account_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `descriptions`
+--
+CREATE TABLE `descriptions` (
+  `tile_id` integer unsigned NOT NULL auto_increment,
+  `tile_description` mediumtext NOT NULL,
+  INDEX (`tile_id`),
+  PRIMARY KEY (`tile_id`),
+  CONSTRAINT `descriptions_fk_tile_id` FOREIGN KEY (`tile_id`) REFERENCES `tiles` (`tile_id`) ON DELETE CASCADE
+) ENGINE=InnoDB;
+--
+-- Table: `account_roles`
+--
+CREATE TABLE `account_roles` (
+  `account_id` integer unsigned NOT NULL,
+  `role_id` integer unsigned NOT NULL,
+  INDEX `account_roles_idx_account_id` (`account_id`),
+  INDEX `account_roles_idx_role_id` (`role_id`),
+  PRIMARY KEY (`account_id`, `role_id`),
+  CONSTRAINT `account_roles_fk_account_id` FOREIGN KEY (`account_id`) REFERENCES `accounts` (`account_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `account_roles_fk_role_id` FOREIGN KEY (`role_id`) REFERENCES `roles` (`role_id`)
+) ENGINE=InnoDB;
+--
+-- Table: `inventories`
+--
+CREATE TABLE `inventories` (
+  `character_id` integer unsigned NOT NULL,
+  `item_id` integer unsigned NOT NULL,
+  `item_quantity` integer unsigned NOT NULL,
+  INDEX `inventories_idx_character_id` (`character_id`),
+  INDEX `inventories_idx_item_id` (`item_id`),
+  PRIMARY KEY (`character_id`, `item_id`),
+  CONSTRAINT `inventories_fk_character_id` FOREIGN KEY (`character_id`) REFERENCES `characters` (`character_id`) ON DELETE CASCADE,
+  CONSTRAINT `inventories_fk_item_id` FOREIGN KEY (`item_id`) REFERENCES `items` (`item_id`)
+) ENGINE=InnoDB;
+--
+-- Table: `skillsets`
+--
+CREATE TABLE `skillsets` (
+  `character_id` integer unsigned NOT NULL,
+  `skill_id` integer unsigned NOT NULL,
+  `item_quantity` integer unsigned NOT NULL,
+  INDEX `skillsets_idx_character_id` (`character_id`),
+  INDEX `skillsets_idx_skill_id` (`skill_id`),
+  PRIMARY KEY (`character_id`, `skill_id`),
+  CONSTRAINT `skillsets_fk_character_id` FOREIGN KEY (`character_id`) REFERENCES `characters` (`character_id`),
+  CONSTRAINT `skillsets_fk_skill_id` FOREIGN KEY (`skill_id`) REFERENCES `skills` (`skill_id`) ON DELETE CASCADE
+) ENGINE=InnoDB;
+SET foreign_key_checks=1;

--- a/ddl/MySQL/upgrade/2-3/001-auto.sql
+++ b/ddl/MySQL/upgrade/2-3/001-auto.sql
@@ -1,0 +1,26 @@
+-- Convert schema 'ddl/_source/deploy/2/001-auto.yml' to 'ddl/_source/deploy/3/001-auto.yml':;
+-- Customised since roles table needs ENGINE=InnoDB before the two constraints are added to account_roles
+
+;
+BEGIN;
+
+;
+ALTER TABLE roles ENGINE=InnoDB;
+
+ALTER TABLE account_roles ENGINE=InnoDB;
+;
+ALTER TABLE account_roles ADD INDEX account_roles_idx_account_id (account_id),
+                          ADD INDEX account_roles_idx_role_id (role_id),
+                          ADD CONSTRAINT account_roles_fk_account_id FOREIGN KEY (account_id) REFERENCES accounts (account_id) ON DELETE CASCADE ON UPDATE CASCADE,
+                          ADD CONSTRAINT account_roles_fk_role_id FOREIGN KEY (role_id) REFERENCES roles (role_id);
+
+;
+ALTER TABLE characters DROP FOREIGN KEY characters_fk_account_id;
+
+;
+ALTER TABLE characters ADD CONSTRAINT characters_fk_account_id FOREIGN KEY (account_id) REFERENCES accounts (account_id) ON DELETE CASCADE ON UPDATE CASCADE;
+
+;
+
+COMMIT;
+

--- a/ddl/PostgreSQL/deploy/3/001-auto-__VERSION.sql
+++ b/ddl/PostgreSQL/deploy/3/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Sun Apr  2 00:26:41 2017
+-- 
+;
+--
+-- Table: dbix_class_deploymenthandler_versions
+--
+CREATE TABLE "dbix_class_deploymenthandler_versions" (
+  "id" serial NOT NULL,
+  "version" character varying(50) NOT NULL,
+  "ddl" text,
+  "upgrade_sql" text,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "dbix_class_deploymenthandler_versions_version" UNIQUE ("version")
+);
+
+;

--- a/ddl/PostgreSQL/deploy/3/001-auto.sql
+++ b/ddl/PostgreSQL/deploy/3/001-auto.sql
@@ -1,0 +1,191 @@
+-- 
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Sun Apr  2 00:26:40 2017
+-- 
+;
+--
+-- Table: accounts
+--
+CREATE TABLE "accounts" (
+  "account_id" serial NOT NULL,
+  "email" character(128) NOT NULL,
+  "password" text,
+  PRIMARY KEY ("account_id"),
+  CONSTRAINT "email" UNIQUE ("email")
+);
+
+;
+--
+-- Table: items
+--
+CREATE TABLE "items" (
+  "item_id" serial NOT NULL,
+  "item_name" character(32) NOT NULL,
+  "item_type" character(32) NOT NULL,
+  "item_data" text NOT NULL,
+  PRIMARY KEY ("item_id")
+);
+
+;
+--
+-- Table: maps
+--
+CREATE TABLE "maps" (
+  "tile_id" integer NOT NULL,
+  "tile_x" integer NOT NULL,
+  "tile_y" integer NOT NULL,
+  "tile_z" integer NOT NULL,
+  PRIMARY KEY ("tile_id"),
+  CONSTRAINT "tile_coords" UNIQUE ("tile_x", "tile_y", "tile_z")
+);
+
+;
+--
+-- Table: roles
+--
+CREATE TABLE "roles" (
+  "role_id" serial NOT NULL,
+  "role" character(255) NOT NULL,
+  "description" character(255),
+  PRIMARY KEY ("role_id")
+);
+
+;
+--
+-- Table: sessions
+--
+CREATE TABLE "sessions" (
+  "id" character(72) NOT NULL,
+  "session_data" text,
+  "expires" integer,
+  PRIMARY KEY ("id")
+);
+
+;
+--
+-- Table: skills
+--
+CREATE TABLE "skills" (
+  "skill_id" serial NOT NULL,
+  "skill_name" character(32) NOT NULL,
+  "skill_requirements" character(32) NOT NULL,
+  "skill_data" text NOT NULL,
+  "skill_prerequisites" text NOT NULL,
+  PRIMARY KEY ("skill_id")
+);
+
+;
+--
+-- Table: tiles
+--
+CREATE TABLE "tiles" (
+  "tile_id" serial NOT NULL,
+  "tile_name" character(32) NOT NULL,
+  "colour_code" character(6) NOT NULL,
+  "move_type" character(10) NOT NULL,
+  PRIMARY KEY ("tile_id")
+);
+
+;
+--
+-- Table: characters
+--
+CREATE TABLE "characters" (
+  "character_id" serial NOT NULL,
+  "character_name" character(32) NOT NULL,
+  "account_id" integer NOT NULL,
+  "character_health" integer NOT NULL,
+  "character_exp" integer NOT NULL,
+  "character_max_ap" integer NOT NULL,
+  "character_ap" integer NOT NULL,
+  PRIMARY KEY ("character_id"),
+  CONSTRAINT "character_name" UNIQUE ("character_name")
+);
+CREATE INDEX "characters_idx_account_id" on "characters" ("account_id");
+
+;
+--
+-- Table: descriptions
+--
+CREATE TABLE "descriptions" (
+  "tile_id" serial NOT NULL,
+  "tile_description" text NOT NULL,
+  PRIMARY KEY ("tile_id")
+);
+
+;
+--
+-- Table: account_roles
+--
+CREATE TABLE "account_roles" (
+  "account_id" integer NOT NULL,
+  "role_id" integer NOT NULL,
+  PRIMARY KEY ("account_id", "role_id")
+);
+CREATE INDEX "account_roles_idx_account_id" on "account_roles" ("account_id");
+CREATE INDEX "account_roles_idx_role_id" on "account_roles" ("role_id");
+
+;
+--
+-- Table: inventories
+--
+CREATE TABLE "inventories" (
+  "character_id" integer NOT NULL,
+  "item_id" integer NOT NULL,
+  "item_quantity" integer NOT NULL,
+  PRIMARY KEY ("character_id", "item_id")
+);
+CREATE INDEX "inventories_idx_character_id" on "inventories" ("character_id");
+CREATE INDEX "inventories_idx_item_id" on "inventories" ("item_id");
+
+;
+--
+-- Table: skillsets
+--
+CREATE TABLE "skillsets" (
+  "character_id" integer NOT NULL,
+  "skill_id" integer NOT NULL,
+  "item_quantity" integer NOT NULL,
+  PRIMARY KEY ("character_id", "skill_id")
+);
+CREATE INDEX "skillsets_idx_character_id" on "skillsets" ("character_id");
+CREATE INDEX "skillsets_idx_skill_id" on "skillsets" ("skill_id");
+
+;
+--
+-- Foreign Key Definitions
+--
+
+;
+ALTER TABLE "characters" ADD CONSTRAINT "characters_fk_account_id" FOREIGN KEY ("account_id")
+  REFERENCES "accounts" ("account_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "descriptions" ADD CONSTRAINT "descriptions_fk_tile_id" FOREIGN KEY ("tile_id")
+  REFERENCES "tiles" ("tile_id") ON DELETE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "account_roles" ADD CONSTRAINT "account_roles_fk_account_id" FOREIGN KEY ("account_id")
+  REFERENCES "accounts" ("account_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "account_roles" ADD CONSTRAINT "account_roles_fk_role_id" FOREIGN KEY ("role_id")
+  REFERENCES "roles" ("role_id") DEFERRABLE;
+
+;
+ALTER TABLE "inventories" ADD CONSTRAINT "inventories_fk_character_id" FOREIGN KEY ("character_id")
+  REFERENCES "characters" ("character_id") ON DELETE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE "inventories" ADD CONSTRAINT "inventories_fk_item_id" FOREIGN KEY ("item_id")
+  REFERENCES "items" ("item_id") DEFERRABLE;
+
+;
+ALTER TABLE "skillsets" ADD CONSTRAINT "skillsets_fk_character_id" FOREIGN KEY ("character_id")
+  REFERENCES "characters" ("character_id") DEFERRABLE;
+
+;
+ALTER TABLE "skillsets" ADD CONSTRAINT "skillsets_fk_skill_id" FOREIGN KEY ("skill_id")
+  REFERENCES "skills" ("skill_id") ON DELETE CASCADE DEFERRABLE;
+
+;

--- a/ddl/PostgreSQL/upgrade/2-3/001-auto.sql
+++ b/ddl/PostgreSQL/upgrade/2-3/001-auto.sql
@@ -1,0 +1,30 @@
+-- Convert schema 'ddl/_source/deploy/2/001-auto.yml' to 'ddl/_source/deploy/3/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+CREATE INDEX account_roles_idx_account_id on account_roles (account_id);
+
+;
+CREATE INDEX account_roles_idx_role_id on account_roles (role_id);
+
+;
+ALTER TABLE account_roles ADD CONSTRAINT account_roles_fk_account_id FOREIGN KEY (account_id)
+  REFERENCES accounts (account_id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+ALTER TABLE account_roles ADD CONSTRAINT account_roles_fk_role_id FOREIGN KEY (role_id)
+  REFERENCES roles (role_id) DEFERRABLE;
+
+;
+ALTER TABLE characters DROP CONSTRAINT characters_fk_account_id;
+
+;
+ALTER TABLE characters ADD CONSTRAINT characters_fk_account_id FOREIGN KEY (account_id)
+  REFERENCES accounts (account_id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+;
+
+COMMIT;
+

--- a/ddl/SQLite/deploy/3/001-auto-__VERSION.sql
+++ b/ddl/SQLite/deploy/3/001-auto-__VERSION.sql
@@ -1,0 +1,18 @@
+-- 
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Sun Apr  2 00:26:41 2017
+-- 
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: dbix_class_deploymenthandler_versions
+--
+CREATE TABLE dbix_class_deploymenthandler_versions (
+  id INTEGER PRIMARY KEY NOT NULL,
+  version varchar(50) NOT NULL,
+  ddl text,
+  upgrade_sql text
+);
+CREATE UNIQUE INDEX dbix_class_deploymenthandler_versions_version ON dbix_class_deploymenthandler_versions (version);
+COMMIT;

--- a/ddl/SQLite/deploy/3/001-auto.sql
+++ b/ddl/SQLite/deploy/3/001-auto.sql
@@ -1,0 +1,133 @@
+-- 
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Sun Apr  2 00:26:40 2017
+-- 
+
+;
+BEGIN TRANSACTION;
+--
+-- Table: accounts
+--
+CREATE TABLE accounts (
+  account_id INTEGER PRIMARY KEY NOT NULL,
+  email char(128) NOT NULL,
+  password text
+);
+CREATE UNIQUE INDEX email ON accounts (email);
+--
+-- Table: items
+--
+CREATE TABLE items (
+  item_id INTEGER PRIMARY KEY NOT NULL,
+  item_name char(32) NOT NULL,
+  item_type char(32) NOT NULL,
+  item_data mediumtext NOT NULL
+);
+--
+-- Table: maps
+--
+CREATE TABLE maps (
+  tile_id INTEGER PRIMARY KEY NOT NULL,
+  tile_x integer NOT NULL,
+  tile_y integer NOT NULL,
+  tile_z integer NOT NULL
+);
+CREATE UNIQUE INDEX tile_coords ON maps (tile_x, tile_y, tile_z);
+--
+-- Table: roles
+--
+CREATE TABLE roles (
+  role_id INTEGER PRIMARY KEY NOT NULL,
+  role char(255) NOT NULL,
+  description char(255)
+);
+--
+-- Table: sessions
+--
+CREATE TABLE sessions (
+  id char(72) NOT NULL,
+  session_data mediumtext,
+  expires integer,
+  PRIMARY KEY (id)
+);
+--
+-- Table: skills
+--
+CREATE TABLE skills (
+  skill_id INTEGER PRIMARY KEY NOT NULL,
+  skill_name char(32) NOT NULL,
+  skill_requirements char(32) NOT NULL,
+  skill_data mediumtext NOT NULL,
+  skill_prerequisites mediumtext NOT NULL
+);
+--
+-- Table: tiles
+--
+CREATE TABLE tiles (
+  tile_id INTEGER PRIMARY KEY NOT NULL,
+  tile_name char(32) NOT NULL,
+  colour_code char(6) NOT NULL,
+  move_type char(10) NOT NULL
+);
+--
+-- Table: characters
+--
+CREATE TABLE characters (
+  character_id INTEGER PRIMARY KEY NOT NULL,
+  character_name char(32) NOT NULL,
+  account_id integer NOT NULL,
+  character_health integer NOT NULL,
+  character_exp integer NOT NULL,
+  character_max_ap integer NOT NULL,
+  character_ap integer NOT NULL,
+  FOREIGN KEY (account_id) REFERENCES accounts(account_id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX characters_idx_account_id ON characters (account_id);
+CREATE UNIQUE INDEX character_name ON characters (character_name);
+--
+-- Table: descriptions
+--
+CREATE TABLE descriptions (
+  tile_id INTEGER PRIMARY KEY NOT NULL,
+  tile_description mediumtext NOT NULL,
+  FOREIGN KEY (tile_id) REFERENCES tiles(tile_id) ON DELETE CASCADE
+);
+--
+-- Table: account_roles
+--
+CREATE TABLE account_roles (
+  account_id integer NOT NULL,
+  role_id integer NOT NULL,
+  PRIMARY KEY (account_id, role_id),
+  FOREIGN KEY (account_id) REFERENCES accounts(account_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (role_id) REFERENCES roles(role_id)
+);
+CREATE INDEX account_roles_idx_account_id ON account_roles (account_id);
+CREATE INDEX account_roles_idx_role_id ON account_roles (role_id);
+--
+-- Table: inventories
+--
+CREATE TABLE inventories (
+  character_id integer NOT NULL,
+  item_id integer NOT NULL,
+  item_quantity integer NOT NULL,
+  PRIMARY KEY (character_id, item_id),
+  FOREIGN KEY (character_id) REFERENCES characters(character_id) ON DELETE CASCADE,
+  FOREIGN KEY (item_id) REFERENCES items(item_id)
+);
+CREATE INDEX inventories_idx_character_id ON inventories (character_id);
+CREATE INDEX inventories_idx_item_id ON inventories (item_id);
+--
+-- Table: skillsets
+--
+CREATE TABLE skillsets (
+  character_id integer NOT NULL,
+  skill_id integer NOT NULL,
+  item_quantity integer NOT NULL,
+  PRIMARY KEY (character_id, skill_id),
+  FOREIGN KEY (character_id) REFERENCES characters(character_id),
+  FOREIGN KEY (skill_id) REFERENCES skills(skill_id) ON DELETE CASCADE
+);
+CREATE INDEX skillsets_idx_character_id ON skillsets (character_id);
+CREATE INDEX skillsets_idx_skill_id ON skillsets (skill_id);
+COMMIT;

--- a/ddl/SQLite/upgrade/2-3/001-auto.sql
+++ b/ddl/SQLite/upgrade/2-3/001-auto.sql
@@ -1,0 +1,24 @@
+-- Convert schema 'ddl/_source/deploy/2/001-auto.yml' to 'ddl/_source/deploy/3/001-auto.yml':;
+
+;
+BEGIN;
+
+;
+CREATE INDEX account_roles_idx_account_id ON account_roles (account_id);
+
+;
+CREATE INDEX account_roles_idx_role_id ON account_roles (role_id);
+
+;
+
+;
+
+;
+DROP INDEX characters_fk_account_id;
+
+;
+
+;
+
+COMMIT;
+

--- a/ddl/_source/deploy/3/001-auto-__VERSION.yml
+++ b/ddl/_source/deploy/3/001-auto-__VERSION.yml
@@ -1,0 +1,91 @@
+---
+schema:
+  procedures: {}
+  tables:
+    dbix_class_deploymenthandler_versions:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - version
+          match_type: ''
+          name: dbix_class_deploymenthandler_versions_version
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        ddl:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: ddl
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: int
+          default_value: ~
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 0
+        upgrade_sql:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: upgrade_sql
+          order: 4
+          size:
+            - 0
+        version:
+          data_type: varchar
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: version
+          order: 2
+          size:
+            - 50
+      indices: []
+      name: dbix_class_deploymenthandler_versions
+      options: []
+      order: 1
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - __VERSION
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args: {}
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11021

--- a/ddl/_source/deploy/3/001-auto.yml
+++ b/ddl/_source/deploy/3/001-auto.yml
@@ -1,0 +1,923 @@
+---
+schema:
+  procedures: {}
+  tables:
+    account_roles:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - account_id
+            - role_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - account_id
+          match_type: ''
+          name: account_roles_fk_account_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - account_id
+          reference_table: accounts
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - role_id
+          match_type: ''
+          name: account_roles_fk_role_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - role_id
+          reference_table: roles
+          type: FOREIGN KEY
+      fields:
+        account_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: account_id
+          order: 1
+          size:
+            - 0
+        role_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: role_id
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - account_id
+          name: account_roles_idx_account_id
+          options: []
+          type: NORMAL
+        - fields:
+            - role_id
+          name: account_roles_idx_role_id
+          options: []
+          type: NORMAL
+      name: account_roles
+      options: []
+      order: 10
+    accounts:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - account_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - email
+          match_type: ''
+          name: email
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        account_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: account_id
+          order: 1
+          size:
+            - 0
+        email:
+          data_type: char
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: email
+          order: 2
+          size:
+            - 128
+        password:
+          data_type: text
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: password
+          order: 3
+          size:
+            - 0
+      indices: []
+      name: accounts
+      options: []
+      order: 1
+    characters:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - character_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - character_name
+          match_type: ''
+          name: character_name
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+        - deferrable: 1
+          expression: ''
+          fields:
+            - account_id
+          match_type: ''
+          name: characters_fk_account_id
+          on_delete: CASCADE
+          on_update: CASCADE
+          options: []
+          reference_fields:
+            - account_id
+          reference_table: accounts
+          type: FOREIGN KEY
+      fields:
+        account_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: account_id
+          order: 3
+          size:
+            - 0
+        character_ap:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: character_ap
+          order: 7
+          size:
+            - 0
+        character_exp:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: character_exp
+          order: 5
+          size:
+            - 0
+        character_health:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: character_health
+          order: 4
+          size:
+            - 0
+        character_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: character_id
+          order: 1
+          size:
+            - 0
+        character_max_ap:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: character_max_ap
+          order: 6
+          size:
+            - 0
+        character_name:
+          data_type: char
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: character_name
+          order: 2
+          size:
+            - 32
+      indices:
+        - fields:
+            - account_id
+          name: characters_idx_account_id
+          options: []
+          type: NORMAL
+      name: characters
+      options: []
+      order: 8
+    descriptions:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - tile_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - tile_id
+          match_type: ''
+          name: descriptions_fk_tile_id
+          on_delete: CASCADE
+          on_update: ''
+          options: []
+          reference_fields:
+            - tile_id
+          reference_table: tiles
+          type: FOREIGN KEY
+      fields:
+        tile_description:
+          data_type: mediumtext
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: tile_description
+          order: 2
+          size:
+            - 0
+        tile_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: tile_id
+          order: 1
+          size:
+            - 0
+      indices: []
+      name: descriptions
+      options: []
+      order: 9
+    inventories:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - character_id
+            - item_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - character_id
+          match_type: ''
+          name: inventories_fk_character_id
+          on_delete: CASCADE
+          on_update: ''
+          options: []
+          reference_fields:
+            - character_id
+          reference_table: characters
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - item_id
+          match_type: ''
+          name: inventories_fk_item_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - item_id
+          reference_table: items
+          type: FOREIGN KEY
+      fields:
+        character_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: character_id
+          order: 1
+          size:
+            - 0
+        item_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: item_id
+          order: 2
+          size:
+            - 0
+        item_quantity:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: item_quantity
+          order: 3
+          size:
+            - 0
+      indices:
+        - fields:
+            - character_id
+          name: inventories_idx_character_id
+          options: []
+          type: NORMAL
+        - fields:
+            - item_id
+          name: inventories_idx_item_id
+          options: []
+          type: NORMAL
+      name: inventories
+      options: []
+      order: 11
+    items:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - item_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+      fields:
+        item_data:
+          data_type: mediumtext
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: item_data
+          order: 4
+          size:
+            - 0
+        item_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: item_id
+          order: 1
+          size:
+            - 0
+        item_name:
+          data_type: char
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: item_name
+          order: 2
+          size:
+            - 32
+        item_type:
+          data_type: char
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: item_type
+          order: 3
+          size:
+            - 32
+      indices: []
+      name: items
+      options: []
+      order: 2
+    maps:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - tile_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - tile_x
+            - tile_y
+            - tile_z
+          match_type: ''
+          name: tile_coords
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: UNIQUE
+      fields:
+        tile_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: tile_id
+          order: 1
+          size:
+            - 0
+        tile_x:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: tile_x
+          order: 2
+          size:
+            - 0
+        tile_y:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: tile_y
+          order: 3
+          size:
+            - 0
+        tile_z:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 0
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: tile_z
+          order: 4
+          size:
+            - 0
+      indices: []
+      name: maps
+      options: []
+      order: 3
+    roles:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - role_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+      fields:
+        description:
+          data_type: char
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: description
+          order: 3
+          size:
+            - 255
+        role:
+          data_type: char
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: role
+          order: 2
+          size:
+            - 255
+        role_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: role_id
+          order: 1
+          size:
+            - 0
+      indices: []
+      name: roles
+      options: []
+      order: 4
+    sessions:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+      fields:
+        expires:
+          data_type: integer
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: expires
+          order: 3
+          size:
+            - 0
+        id:
+          data_type: char
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: id
+          order: 1
+          size:
+            - 72
+        session_data:
+          data_type: mediumtext
+          default_value: ~
+          is_nullable: 1
+          is_primary_key: 0
+          is_unique: 0
+          name: session_data
+          order: 2
+          size:
+            - 0
+      indices: []
+      name: sessions
+      options: []
+      order: 5
+    skills:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - skill_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+      fields:
+        skill_data:
+          data_type: mediumtext
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: skill_data
+          order: 4
+          size:
+            - 0
+        skill_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: skill_id
+          order: 1
+          size:
+            - 0
+        skill_name:
+          data_type: char
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: skill_name
+          order: 2
+          size:
+            - 32
+        skill_prerequisites:
+          data_type: mediumtext
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: skill_prerequisites
+          order: 5
+          size:
+            - 0
+        skill_requirements:
+          data_type: char
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: skill_requirements
+          order: 3
+          size:
+            - 32
+      indices: []
+      name: skills
+      options: []
+      order: 6
+    skillsets:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - character_id
+            - skill_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - character_id
+          match_type: ''
+          name: skillsets_fk_character_id
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields:
+            - character_id
+          reference_table: characters
+          type: FOREIGN KEY
+        - deferrable: 1
+          expression: ''
+          fields:
+            - skill_id
+          match_type: ''
+          name: skillsets_fk_skill_id
+          on_delete: CASCADE
+          on_update: ''
+          options: []
+          reference_fields:
+            - skill_id
+          reference_table: skills
+          type: FOREIGN KEY
+      fields:
+        character_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: character_id
+          order: 1
+          size:
+            - 0
+        item_quantity:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: item_quantity
+          order: 3
+          size:
+            - 0
+        skill_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: skill_id
+          order: 2
+          size:
+            - 0
+      indices:
+        - fields:
+            - character_id
+          name: skillsets_idx_character_id
+          options: []
+          type: NORMAL
+        - fields:
+            - skill_id
+          name: skillsets_idx_skill_id
+          options: []
+          type: NORMAL
+      name: skillsets
+      options: []
+      order: 12
+    tiles:
+      constraints:
+        - deferrable: 1
+          expression: ''
+          fields:
+            - tile_id
+          match_type: ''
+          name: ''
+          on_delete: ''
+          on_update: ''
+          options: []
+          reference_fields: []
+          reference_table: ''
+          type: PRIMARY KEY
+      fields:
+        colour_code:
+          data_type: char
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: colour_code
+          order: 3
+          size:
+            - 6
+        move_type:
+          data_type: char
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: move_type
+          order: 4
+          size:
+            - 10
+        tile_id:
+          data_type: integer
+          default_value: ~
+          extra:
+            unsigned: 1
+          is_auto_increment: 1
+          is_nullable: 0
+          is_primary_key: 1
+          is_unique: 0
+          name: tile_id
+          order: 1
+          size:
+            - 0
+        tile_name:
+          data_type: char
+          default_value: ~
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 0
+          name: tile_name
+          order: 2
+          size:
+            - 32
+      indices: []
+      name: tiles
+      options: []
+      order: 7
+  triggers: {}
+  views: {}
+translator:
+  add_drop_table: 0
+  filename: ~
+  no_comments: 0
+  parser_args:
+    sources:
+      - Account
+      - AccountRole
+      - Character
+      - Description
+      - Inventory
+      - Item
+      - Map
+      - Role
+      - Session
+      - Skill
+      - Skillset
+      - Tile
+  parser_type: SQL::Translator::Parser::DBIx::Class
+  producer_args: {}
+  producer_type: SQL::Translator::Producer::YAML
+  show_warnings: 0
+  trace: 0
+  version: 0.11021

--- a/lib/RPGCat/Schema.pm
+++ b/lib/RPGCat/Schema.pm
@@ -7,7 +7,7 @@ extends 'DBIx::Class::Schema';
 
 __PACKAGE__->load_namespaces;
 
-our $VERSION = 2;
+our $VERSION = 3;
 
 __PACKAGE__->meta->make_immutable(inline_constructor => 0);
 1;


### PR DESCRIPTION
NOTE: The auto-generated ddl files didn't work for MySQL because
the roles table was MyISAM still and needed to be InnoDB before
the account_roles FK constraints could be added. Fortunately the
fix was as simple as moving the ALTER TABLE roles line to the top
of the file ddl/MySQL/deploy/3/001-auto.sql

To test the upgrade multiple times during debugging the error, I
followed this procdure.

Delete the database in the appropriate way
(DROP DATABASE rpgcat_db in MySQL; rm rpgcat.db with SQLite)

Then install version 2 schema (-c specifies connection string)

./script/rpgcat_dh.pl -s RPGCat::Schema -I lib -o ./ddl/ \
    -c 'dbi:mysql:rpgcat_db;user=rpgcat_user;password=rpgcat_pass' \
    install --target 2

Once that's done, restart the application server and it should
upgrade the db schema to v3 (or die with a horrible error)