### PR TITLE
UTF8 database access

### DIFF
--- a/lib/RPGCat/Model/DB.pm
+++ b/lib/RPGCat/Model/DB.pm
@@ -10,6 +10,9 @@ __PACKAGE__->config(
         dsn => 'dbi:mysql:rpgcat_db',
         user => 'rpgcat_user',
         password => 'rpgcat_pass',
+
+        # UTF8 please!
+        mysql_enable_utf8 => 1,
     }
 );
 


### PR DESCRIPTION
In order for this to work, the database and tables must also be
set to use utf8mb4 instead of latin1. If this is not the case,
weird things will happen.

If using auto-deploy via DBIx::Class, you should set your database
defaults before starting the application.

CREATE DATABASE rpgcat_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

If the database is already created, you can use ALTER DATABASE with the same
parameters. This will not change existing tables - you will have to update
them using something like the following (use purely for guidance!):

mysqldump rpgcat_db > dump.sql
cp dump.sql dump-fixed.sql
vim dump-fixed.sql
:%s/DEFAULT CHARACTER SET latin1/DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci/
:%s/DEFAULT CHARSET=latin1/DEFAULT CHARSET=utf8mb4/
:wq
mysql rpgcat_db < dump-fixed.sql